### PR TITLE
Fix JavaScript build when using Webpack 5

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,3 +80,12 @@ android {
 dependencies {
     "kapt"(exercise("compile"))
 }
+
+// Fix failure when building JavaScript target (with Webpack 5).
+// https://youtrack.jetbrains.com/issue/KT-48273
+// todo: Remove once Kotlin is upgraded to 1.5.30.
+afterEvaluate {
+    rootProject.extensions.configure<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension> {
+        versions.webpackDevServer.version = "4.0.0"
+    }
+}


### PR DESCRIPTION
Was seeing the following failure when attempting to build JavaScript target:

```
> Task :app:jsBrowserDevelopmentRun FAILED
[webpack-cli] Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
 - configuration has an unknown property '_assetEmittingWrittenFiles'. These properties are valid:
   object { bonjour?, client?, compress?, dev?, firewall?, headers?, historyApiFallback?, host?, hot?, http2?, https?, liveReload?, onAfterSetupMiddleware?, onBeforeSetupMiddleware?, onListening?, open?, port?, proxy?, public?, setupExitSignals?, static?, transportMode?, watchFiles? }

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:jsBrowserDevelopmentRun'.
> [webpack-cli] Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
   - configuration has an unknown property '_assetEmittingWrittenFiles'. These properties are valid:
     object { bonjour?, client?, compress?, dev?, firewall?, headers?, historyApiFallback?, host?, hot?, http2?, https?, liveReload?, onAfterSetupMiddleware?, onBeforeSetupMiddleware?, onListening?, open?, port?, proxy?, public?, setupExitSignals?, static?, transportMode?, watchFiles? }
```

Fix suggested in https://youtrack.jetbrains.com/issue/KT-48273.