### PR TITLE
Clean up/remove unnecessary dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,11 +27,6 @@ kotlin {
                 implementation(libs.tuulbox.logging)
                 implementation(libs.tuulbox.encoding)
                 implementation(libs.tuulbox.coroutines)
-
-                // todo: Remove once kotlinx.datetime 0.3.3+ is transitively pulled in.
-                // This is needed because kotlinx.datetime 0.3.2 (which is not Kotlin 1.7.0 compatible) is transitively
-                // pull in, so we explicitly upgrade to a version that is compatible with Kotlin 1.7.x.
-                implementation(libs.datetime)
             }
         }
 
@@ -42,17 +37,6 @@ kotlin {
                 implementation(libs.exercise.annotations)
                 implementation(libs.bundles.krayon)
             }
-        }
-
-        val nativeMain by creating {
-            dependencies {
-                implementation(libs.coroutines.macosx64)
-                implementation(libs.stately)
-            }
-        }
-
-        val macosX64Main by getting {
-            dependsOn(nativeMain)
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.java8)
 }
 
 allprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,8 +23,6 @@ compose-tooling = { module = "androidx.compose.ui:ui-tooling-preview", version.r
 compose-ui = { module = "androidx.compose.ui:ui", version = "compose" }
 compose-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.6.4" }
-coroutines-macosx64 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-macosx64", version = "1.6.0-native-mt!!" }
-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.4.0" }
 exercise-annotations = { module = "com.juul.exercise:annotations", version.ref = "exercise" }
 exercise-compile = { module = "com.juul.exercise:compile", version.ref = "exercise" }
 kable = { module = "com.juul.kable:core", version.ref = "kable" }
@@ -33,7 +31,6 @@ krayon-scale = { module = "com.juul.krayon:scale", version.ref = "krayon" }
 krayon-selection = { module = "com.juul.krayon:selection", version.ref = "krayon" }
 krayon-shape = { module = "com.juul.krayon:shape", version.ref = "krayon" }
 krayon-view = { module = "com.juul.krayon:element-view", version.ref = "krayon" }
-stately = { module = "co.touchlab:stately-isolate", version = "1.2.3" }
 tuulbox-coroutines = { module = "com.juul.tuulbox:coroutines", version.ref = "tuulbox" }
 tuulbox-encoding = { module = "com.juul.tuulbox:encoding", version.ref = "tuulbox" }
 tuulbox-logging = { module = "com.juul.tuulbox:logging", version.ref = "tuulbox" }
@@ -59,6 +56,5 @@ krayon = [
 
 [plugins]
 android-application = { id = "com.android.library", version.ref = "agp" }
-java8 = { id = "net.mbonnin.one.eight", version = "0.2" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
- `coroutines-native-mt` and Stately are not needed with new memory model
- datetime dependency workaround is no longer needed
- No longer need to force Java8 for Android projects