### PR TITLE
Use JDK 17 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - uses: actions/cache@v3
         with:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 }
 
 kotlin {
+    jvmToolchain(11)
+
     android()
     js {
         browser()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 kotlin.js.compiler=ir
 kotlin.mpp.androidSourceSetLayoutVersion=2


### PR DESCRIPTION
Newer versions of AGP require JDK 17:

```
An exception occurred applying plugin request [id: 'com.android.library', artifact: 'com.android.tools.build:gradle:null']
> Failed to apply plugin 'com.android.internal.library'.
   > Android Gradle plugin requires Java 17 to run. You are currently using Java 11.
      Your current JDK is located in /Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.18-10/x64/Contents/Home
      You can try some of the following options:
       - changing the IDE settings.
       - changing the JAVA_HOME environment variable.
       - changing `org.gradle.java.home` in `gradle.properties`.
```

...and #207 is [failing](https://github.com/JuulLabs/sensortag/actions/runs/4698771086/jobs/8331456953?pr=207) due to Java incompatibilities:

```
e: java.lang.UnsupportedClassVersionError: androidx/compose/compiler/plugins/kotlin/ComposeComponentRegistrar has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```