### PR TITLE
Add Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    ":disableRateLimiting"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Kotlin, KSP and Compose",
+      "matchPackagePrefixes": [
+        "org.jetbrains.kotlin:kotlin",
+        "com.google.devtools.ksp",
+        "androidx.compose.compiler"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds Renovate configuration which groups upgrades for Kotlin, KSP and Compose compiler into a single PR (as those dependencies are often tightly coupled together).

Inspired by:
- [cashapp/molecule/renovate.json5](https://github.com/cashapp/molecule/blob/310519c9365847cc630101dfc1b160450a805de5/renovate.json5)
- [fardavide/Shuttle/renovate.json](https://github.com/fardavide/Shuttle/blob/f45de62c8e455de7bde48b4268a0cb66ccef050d/renovate.json)
- [HarukeyUA/mastodroid/renovate.json](https://github.com/HarukeyUA/mastodroid/blob/aafbe986b9a4d1a95b2f6f1c57477591c3f79d70/renovate.json)
- [PaulWoitaschek/Voice/renovate.json](https://github.com/PaulWoitaschek/Voice/blob/08ddf39bb0283df92cdcb4ae14828aa1573a753a/renovate.json)

Example of Renovate PR created with grouping: https://github.com/PaulWoitaschek/Voice/pull/1832