### PR TITLE
Fix Renovate matching rules for Kotlin

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,8 @@
     {
       "groupName": "Kotlin, KSP and Compose",
       "matchPackagePrefixes": [
-        "org.jetbrains.kotlin:kotlin",
+        "org.jetbrains.kotlin:",
+        "org.jetbrains.kotlin.",
         "com.google.devtools.ksp",
         "androidx.compose.compiler"
       ]


### PR DESCRIPTION
With #243 I added support for grouping Kotlin, KSP and Compose dependency updates, but I used [Molecule library](https://github.com/cashapp/molecule/blob/310519c9365847cc630101dfc1b160450a805de5/renovate.json5) for inspiration, but they reference Kotlin as a **library** (via `org.jetbrains.kotlin:kotlin-gradle-plugin`) whereas we reference Kotlin as a **plugin**: `org.jetbrains.kotlin.multiplatform`

This PR simply fixes what prefixes we match against to properly match the Kotlin plugin dependency (to have it grouped with KSP and Compose upgrades).