### PR TITLE
Use `latest` version of GitHub virtual environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3


### PR DESCRIPTION
These version bumps have been reliable and having to manually bump the version(s) adds a bit of churn. I'd rather not waste our time w/ reviewing it, and on the unlikely chance that something breaks w/ `-latest`, I'm hopeful that the time invested to resolve it will remain less than review time for the version bumps. 🤞 