### PR TITLE
Migrate to `gradle/actions/setup-gradle`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-
-      - name: assemble
-        uses: gradle/gradle-build-action@v3
+      - uses: gradle/actions/setup-gradle@v3
         with:
-          arguments: assemble
+          validate-wrappers: true
 
-      - name: check
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: check
+      - run: ./gradlew assemble
+      - run: ./gradlew check


### PR DESCRIPTION
The currently used [`gradle/gradle-build-action`](https://github.com/gradle/gradle-build-action/blob/main/README.md) is deprecated in favor of [`gradle/actions/setup-gradle`](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md).