### PR TITLE
Fix `appendChild` error by moving `script` within `body`

### DIFF
--- a/app/src/jsMain/resources/index.html
+++ b/app/src/jsMain/resources/index.html
@@ -4,6 +4,8 @@
         <meta charset="UTF-8">
         <title>SensorTag</title>
         <link rel="stylesheet" href="styles.css">
+    </head>
+    <body>
         <script type="text/javascript" src="app.js"></script>
         <script type="text/javascript">
             var script = new app.com.juul.sensortag.Script();
@@ -17,8 +19,6 @@
                 document.getElementById('movement').innerHTML = "x: " + x + "<br/>y: " + y + "<br/>z: " + z;
             });
         </script>
-    </head>
-    <body>
         <h1>SensorTag</h1>
         <button onclick="script.connect();">Connect</button>
         <button onclick="script.disconnect();">Disconnect</button>


### PR DESCRIPTION
On Safari, we'd always see the following error on load:

![Screenshot 2024-07-31 at 1 47 23 PM](https://github.com/user-attachments/assets/fd0ce755-8aed-4652-954d-71e8a81a78ba)

As a workaround to [KT-68722](https://youtrack.jetbrains.com/issue/KT-68722), `script` is moved within `body` to fix error.