### PR TITLE
Dispatch coroutine scope exceptions to `window`

### DIFF
--- a/app/src/jsMain/kotlin/Script.kt
+++ b/app/src/jsMain/kotlin/Script.kt
@@ -9,6 +9,8 @@ import com.juul.kable.requestPeripheral
 import com.juul.khronicle.ConsoleLogger
 import com.juul.khronicle.ConstantTagGenerator
 import com.juul.khronicle.Log
+import kotlinx.browser.window
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.await
@@ -17,6 +19,16 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.w3c.dom.ErrorEvent
+import org.w3c.dom.ErrorEventInit
+
+private val scope = CoroutineScope(
+    Job() + CoroutineExceptionHandler { _, cause ->
+        // Deliver unhandled errors to `window` so that Chrome shows error overlay.
+        // https://github.com/Kotlin/kotlinx.coroutines/issues/2407#issuecomment-1472409187
+        window.dispatchEvent(ErrorEvent("error", ErrorEventInit(error = cause)))
+    }
+)
 
 @JsExport
 class Script {
@@ -26,7 +38,6 @@ class Script {
         Log.dispatcher.install(ConsoleLogger)
     }
 
-    private val scope = CoroutineScope(Job())
     private var connection: Job? = null
 
     val availability = BluetoothAvailability(Bluetooth.availability).apply { launchIn(scope) }


### PR DESCRIPTION
Chrome has the ability to show an overlay when an unhandled error occurs, unfortunately exceptions that occur within a coroutine scope were not propagated to the `window`. As a result, unhandled errors would be "silently" logged to console but not shown on the web page.

It appears that there are future plans (https://github.com/Kotlin/kotlinx.coroutines/issues/2407) to provide official mechanisms for this propagation (of unhandled errors occurring in coroutines); until that lands, we manually forward our primary scope's exceptions to the `window`.

For example:

![Screenshot 2024-07-31 at 1 55 26 PM](https://github.com/user-attachments/assets/cd126be5-c7cd-4ae3-b9d8-d98545eb1ce9)
