### PR TITLE
Configure Webapp for CI and pages distribution

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -11,6 +11,7 @@ defaults:
 
 jobs:
   build:
+    name: Build
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,7 +1,5 @@
 name: Webapp
 on:
-  # todo: remove (for debugging)
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,51 @@
+name: Webapp
+on:
+  # todo: remove (for debugging)
+  pull_request:
+  push:
+    branches:
+      - main
+
+env:
+  GRADLE_OPTS: -Dorg.gradle.daemon=false
+
+jobs:
+  build:
+    name: Package Browser Distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - uses: gradle/actions/setup-gradle@v4
+      - run: ./gradlew jsBrowserDistribution
+      - run: >
+          tar
+          --dereference --hard-dereference
+          --directory app/build/dist/js/productionExecutable
+          -cvf '${{ runner.temp }}/artifact.tar'
+          --exclude=.git
+          --exclude=.github
+          .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          if-no-files-found: error
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -1,18 +1,13 @@
-name: Android
+name: Webapp
 on:
   pull_request:
-  # Trigger on merges to `main` to allow `gradle/gradle-build-action` runs to write their caches.
-  # https://github.com/gradle/gradle-build-action#using-the-caches-read-only
-  push:
-    branches:
-      - main
 
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false
 
 jobs:
   build:
-    name: Build
+    name: Browser Distribution
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,5 +16,4 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - uses: gradle/actions/setup-gradle@v4
-      - run: ./gradlew assemble
-      - run: ./gradlew check
+      - run: ./gradlew jsBrowserDistribution

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ In Xcode, configure signing, then run.
 
 ![JavaScript browser app screen recording](artwork/javascript.gif)
 
-To build and launch the demo within a browser window, run:
+A live demo can be viewed [here](https://juullabs.github.io/sensortag), or to build and launch the
+demo within a browser window on your local machine, run:
 
 ```shell
 ./gradlew jsBrowserRun


### PR DESCRIPTION
PR adds Webapp build to CI and adds deployment of the SensorTag Webapp to GitHub pages.

Successfully deployed to https://juullabs.github.io/sensortag (while testing).