### PR TITLE
Add battery level of SensorTag to App bar

### DIFF
--- a/app/src/commonMain/kotlin/SensorTag.kt
+++ b/app/src/commonMain/kotlin/SensorTag.kt
@@ -48,6 +48,11 @@ private val movementPeriodCharacteristic = characteristicOf(
     characteristic = movementPeriodUuid,
 )
 
+private val batteryCharacteristic = characteristicOf(
+    service = Bluetooth.BaseUuid + 0x180F,
+    characteristic = Bluetooth.BaseUuid + 0x2A19,
+)
+
 private val rssiInterval = 5.seconds
 
 class SensorTag(private val peripheral: Peripheral) {
@@ -63,6 +68,7 @@ class SensorTag(private val peripheral: Peripheral) {
             movementConfigurationUuid,
             movementPeriodUuid,
             clientCharacteristicConfigUuid,
+            batteryCharacteristic.serviceUuid,
         )
 
         val scanner by lazy {
@@ -80,6 +86,12 @@ class SensorTag(private val peripheral: Peripheral) {
     }
 
     val state = peripheral.state
+
+    /** Battery percent level (0-100). */
+    val battery = peripheral
+        .observe(batteryCharacteristic)
+        .map(ByteArray::first)
+        .map(Byte::toInt)
 
     private val _rssi = MutableStateFlow<Int?>(null)
     val rssi = _rssi.asStateFlow()

--- a/app/src/commonMain/kotlin/SensorTag.kt
+++ b/app/src/commonMain/kotlin/SensorTag.kt
@@ -23,6 +23,7 @@ import kotlin.coroutines.coroutineContext
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.flow.onStart
 
 private const val GYRO_MULTIPLIER = 500f / 65536f
 
@@ -88,10 +89,11 @@ class SensorTag(private val peripheral: Peripheral) {
     val state = peripheral.state
 
     /** Battery percent level (0-100). */
-    val battery = peripheral
+    val battery: Flow<Int?> = peripheral
         .observe(batteryCharacteristic)
-        .map(ByteArray::first)
-        .map(Byte::toInt)
+        .onStart { emit(byteArrayOf()) }
+        .map(ByteArray::firstOrNull)
+        .map { it?.toInt() }
 
     private val _rssi = MutableStateFlow<Int?>(null)
     val rssi = _rssi.asStateFlow()

--- a/app/src/commonMain/kotlin/features/sensor/SensorScreen.kt
+++ b/app/src/commonMain/kotlin/features/sensor/SensorScreen.kt
@@ -48,6 +48,7 @@ import com.juul.sensortag.icons.Battery3Bar
 import com.juul.sensortag.icons.Battery4Bar
 import com.juul.sensortag.icons.Battery5Bar
 import com.juul.sensortag.icons.BatteryFull
+import com.juul.sensortag.icons.BatteryUnknown
 import kotlinx.coroutines.flow.Flow
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -77,12 +78,13 @@ class SensorScreen : Screen {
                     },
                     title = { Text("SensorTag: ${viewState::class.simpleName}") },
                     actions = {
+                        val level = (viewState as? ViewState.Connected)?.battery
                         if (viewState is ViewState.Connected) {
                             Icon(
-                                imageVector = batteryIconForLevel(viewState.battery),
-                                contentDescription = "${viewState.battery}% battery level",
+                                imageVector = batteryIconForLevel(level),
+                                contentDescription = "${level ?: "Unknown"}% battery level",
                             )
-                            Text("${viewState.battery}%")
+                            Text("${level ?: "?"}%")
                             Spacer(Modifier.size(5.dp))
                         }
                     }
@@ -166,15 +168,16 @@ private val ClosedRange<Duration>.inWholeMilliseconds: LongRange
 private fun LongRange.toFloat(): ClosedFloatingPointRange<Float> =
     start.toFloat()..endInclusive.toFloat()
 
-private fun batteryIconForLevel(level: Int): ImageVector {
+private fun batteryIconForLevel(level: Int?): ImageVector {
     return when {
+        level == null -> Icons.AutoMirrored.Outlined.BatteryUnknown
         level == 100 -> Icons.Filled.BatteryFull
         level >= 83 -> Icons.Filled.Battery5Bar
         level >= 66 -> Icons.Filled.Battery4Bar
         level >= 50 -> Icons.Filled.Battery3Bar
         level >= 33 -> Icons.Filled.Battery2Bar
         level >= 16 -> Icons.Filled.Battery1Bar
-        level >= 0 ->  Icons.Filled.Battery0Bar
+        level >= 0 -> Icons.Filled.Battery0Bar
         else -> error("Unsupported battery level: $level")
     }
 }

--- a/app/src/commonMain/kotlin/features/sensor/SensorScreen.kt
+++ b/app/src/commonMain/kotlin/features/sensor/SensorScreen.kt
@@ -20,11 +20,14 @@ import androidx.compose.material.TopAppBar
 import androidx.compose.material.contentColorFor
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.model.rememberScreenModel
@@ -36,7 +39,15 @@ import com.juul.sensortag.SensorTag
 import com.juul.sensortag.bluetooth.rememberSystemControl
 import com.juul.sensortag.bluetooth.requirements.rememberBluetoothRequirementsFactory
 import com.juul.sensortag.features.components.BluetoothDisabled
+import com.juul.sensortag.features.scan.DeviceLocator.State.Scanning
 import com.juul.sensortag.features.sensor.chart.Sample
+import com.juul.sensortag.icons.Battery0Bar
+import com.juul.sensortag.icons.Battery1Bar
+import com.juul.sensortag.icons.Battery2Bar
+import com.juul.sensortag.icons.Battery3Bar
+import com.juul.sensortag.icons.Battery4Bar
+import com.juul.sensortag.icons.Battery5Bar
+import com.juul.sensortag.icons.BatteryFull
 import kotlinx.coroutines.flow.Flow
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -65,6 +76,16 @@ class SensorScreen : Screen {
                         }
                     },
                     title = { Text("SensorTag: ${viewState::class.simpleName}") },
+                    actions = {
+                        if (viewState is ViewState.Connected) {
+                            Icon(
+                                imageVector = batteryIconForLevel(viewState.battery),
+                                contentDescription = "${viewState.battery}% battery level",
+                            )
+                            Text("${viewState.battery}%")
+                            Spacer(Modifier.size(5.dp))
+                        }
+                    }
                 )
 
                 ProvideTextStyle(
@@ -144,3 +165,16 @@ private val ClosedRange<Duration>.inWholeMilliseconds: LongRange
 
 private fun LongRange.toFloat(): ClosedFloatingPointRange<Float> =
     start.toFloat()..endInclusive.toFloat()
+
+private fun batteryIconForLevel(level: Int): ImageVector {
+    return when {
+        level == 100 -> Icons.Filled.BatteryFull
+        level >= 83 -> Icons.Filled.Battery5Bar
+        level >= 66 -> Icons.Filled.Battery4Bar
+        level >= 50 -> Icons.Filled.Battery3Bar
+        level >= 33 -> Icons.Filled.Battery2Bar
+        level >= 16 -> Icons.Filled.Battery1Bar
+        level >= 0 ->  Icons.Filled.Battery0Bar
+        else -> error("Unsupported battery level: $level")
+    }
+}

--- a/app/src/commonMain/kotlin/features/sensor/SensorScreenModel.kt
+++ b/app/src/commonMain/kotlin/features/sensor/SensorScreenModel.kt
@@ -49,6 +49,7 @@ class SensorScreenModel(
                     when (state) {
                         is State.Connecting -> flowOf(ViewState.Connecting)
                         is State.Connected -> combine(
+                            sensorTag.battery,
                             sensorTag.rssi,
                             sensorTag.periodMillis,
                             ViewState::Connected,

--- a/app/src/commonMain/kotlin/features/sensor/ViewState.kt
+++ b/app/src/commonMain/kotlin/features/sensor/ViewState.kt
@@ -6,7 +6,7 @@ sealed class ViewState {
     data object BluetoothOff : ViewState()
     data object Connecting : ViewState()
     data class Connected(
-        val battery: Int,
+        val battery: Int?,
         val rssi: Int?,
         val period: Duration,
     ) : ViewState()

--- a/app/src/commonMain/kotlin/features/sensor/ViewState.kt
+++ b/app/src/commonMain/kotlin/features/sensor/ViewState.kt
@@ -6,6 +6,7 @@ sealed class ViewState {
     data object BluetoothOff : ViewState()
     data object Connecting : ViewState()
     data class Connected(
+        val battery: Int,
         val rssi: Int?,
         val period: Duration,
     ) : ViewState()

--- a/app/src/commonMain/kotlin/icons/BatteryFull.kt
+++ b/app/src/commonMain/kotlin/icons/BatteryFull.kt
@@ -1,0 +1,30 @@
+package com.juul.sensortag.icons
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+// Copied from `androidx.compose.material:material-icons-extended` library as suggested by:
+// https://developer.android.com/jetpack/compose/resources#icons
+
+val Icons.Filled.BatteryFull: ImageVector by lazy {
+    materialIcon(name = "Filled.BatteryFull") {
+        materialPath {
+            moveTo(15.67f, 4.0f)
+            horizontalLineTo(14.0f)
+            verticalLineTo(2.0f)
+            horizontalLineToRelative(-4.0f)
+            verticalLineToRelative(2.0f)
+            horizontalLineTo(8.33f)
+            curveTo(7.6f, 4.0f, 7.0f, 4.6f, 7.0f, 5.33f)
+            verticalLineToRelative(15.33f)
+            curveTo(7.0f, 21.4f, 7.6f, 22.0f, 8.33f, 22.0f)
+            horizontalLineToRelative(7.33f)
+            curveToRelative(0.74f, 0.0f, 1.34f, -0.6f, 1.34f, -1.33f)
+            verticalLineTo(5.33f)
+            curveTo(17.0f, 4.6f, 16.4f, 4.0f, 15.67f, 4.0f)
+            close()
+        }
+    }
+}

--- a/app/src/commonMain/kotlin/icons/BatteryUnknown.kt
+++ b/app/src/commonMain/kotlin/icons/BatteryUnknown.kt
@@ -1,0 +1,50 @@
+package com.juul.sensortag.icons
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+// Copied from `androidx.compose.material:material-icons-extended` library as suggested by:
+// https://developer.android.com/jetpack/compose/resources#icons
+
+val Icons.AutoMirrored.Outlined.BatteryUnknown: ImageVector by lazy {
+    materialIcon(name = "AutoMirrored.Outlined.BatteryUnknown") {
+        materialPath {
+            moveTo(15.67f, 4.0f)
+            lineTo(14.0f, 4.0f)
+            lineTo(14.0f, 2.0f)
+            horizontalLineToRelative(-4.0f)
+            verticalLineToRelative(2.0f)
+            lineTo(8.33f, 4.0f)
+            curveTo(7.6f, 4.0f, 7.0f, 4.6f, 7.0f, 5.33f)
+            verticalLineToRelative(15.33f)
+            curveTo(7.0f, 21.4f, 7.6f, 22.0f, 8.33f, 22.0f)
+            horizontalLineToRelative(7.33f)
+            curveToRelative(0.74f, 0.0f, 1.34f, -0.6f, 1.34f, -1.33f)
+            lineTo(17.0f, 5.33f)
+            curveTo(17.0f, 4.6f, 16.4f, 4.0f, 15.67f, 4.0f)
+            close()
+            moveTo(13.0f, 18.0f)
+            horizontalLineToRelative(-2.0f)
+            verticalLineToRelative(-2.0f)
+            horizontalLineToRelative(2.0f)
+            verticalLineToRelative(2.0f)
+            close()
+            moveTo(14.3f, 12.69f)
+            reflectiveCurveToRelative(-0.38f, 0.42f, -0.67f, 0.71f)
+            curveToRelative(-0.48f, 0.48f, -0.83f, 1.15f, -0.83f, 1.6f)
+            horizontalLineToRelative(-1.6f)
+            curveToRelative(0.0f, -0.83f, 0.46f, -1.52f, 0.93f, -2.0f)
+            lineToRelative(0.93f, -0.94f)
+            curveToRelative(0.27f, -0.27f, 0.44f, -0.65f, 0.44f, -1.06f)
+            curveToRelative(0.0f, -0.83f, -0.67f, -1.5f, -1.5f, -1.5f)
+            reflectiveCurveToRelative(-1.5f, 0.67f, -1.5f, 1.5f)
+            lineTo(9.0f, 11.0f)
+            curveToRelative(0.0f, -1.66f, 1.34f, -3.0f, 3.0f, -3.0f)
+            reflectiveCurveToRelative(3.0f, 1.34f, 3.0f, 3.0f)
+            curveToRelative(0.0f, 0.66f, -0.27f, 1.26f, -0.7f, 1.69f)
+            close()
+        }
+    }
+}

--- a/app/src/commonMain/kotlin/icons/BatteryXBar.kt
+++ b/app/src/commonMain/kotlin/icons/BatteryXBar.kt
@@ -1,0 +1,47 @@
+package com.juul.sensortag.icons
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.PathBuilder
+
+val Icons.Filled.Battery0Bar: ImageVector by lazy { batteryIcon(0) }
+val Icons.Filled.Battery1Bar: ImageVector by lazy { batteryIcon(1) }
+val Icons.Filled.Battery2Bar: ImageVector by lazy { batteryIcon(2) }
+val Icons.Filled.Battery3Bar: ImageVector by lazy { batteryIcon(3) }
+val Icons.Filled.Battery4Bar: ImageVector by lazy { batteryIcon(4) }
+val Icons.Filled.Battery5Bar: ImageVector by lazy { batteryIcon(5) }
+
+private fun batteryIcon(number: Int) = materialIcon(name = "Filled.Battery${number}Bar") {
+    materialPath {
+        path(number)
+    }
+}
+
+private val verticalLineRelativeToValues = arrayOf(14f, 12f, 10f, 8f, 6f, 4f)
+
+// Adapted from `androidx.compose.material:material-icons-extended` library as suggested by:
+// https://developer.android.com/jetpack/compose/resources#icons
+private fun PathBuilder.path(number: Int) {
+    moveTo(17.0f, 5.0f)
+    verticalLineToRelative(16.0f)
+    curveToRelative(0.0f, 0.55f, -0.45f, 1.0f, -1.0f, 1.0f)
+    horizontalLineTo(8.0f)
+    curveToRelative(-0.55f, 0.0f, -1.0f, -0.45f, -1.0f, -1.0f)
+    verticalLineTo(5.0f)
+    curveToRelative(0.0f, -0.55f, 0.45f, -1.0f, 1.0f, -1.0f)
+    horizontalLineToRelative(2.0f)
+    verticalLineTo(2.0f)
+    horizontalLineToRelative(4.0f)
+    verticalLineToRelative(2.0f)
+    horizontalLineToRelative(2.0f)
+    curveTo(16.55f, 4.0f, 17.0f, 4.45f, 17.0f, 5.0f)
+    close()
+    moveTo(15.0f, 6.0f)
+    horizontalLineTo(9.0f)
+    verticalLineToRelative(verticalLineRelativeToValues[number])
+    horizontalLineToRelative(6.0f)
+    verticalLineTo(6.0f)
+    close()
+}


### PR DESCRIPTION
Example:

![Screenshot 2024-10-24 at 12 07 45 PM](https://github.com/user-attachments/assets/51b2b167-a131-40c9-8d2b-76ccedabfb03)

_I kept having the battery die at inopportune times, this will help to remind me when to order a new battery._ 🙃 
