### PR TITLE
Improve handling of bluetooth disabled state

### DIFF
--- a/bluetooth/src/appleMain/kotlin/requirements/AppleBluetoothRequirements.kt
+++ b/bluetooth/src/appleMain/kotlin/requirements/AppleBluetoothRequirements.kt
@@ -16,7 +16,7 @@ import platform.darwin.NSObject
 // https://chrismaddern.com/determine-whether-bluetooth-is-enabled-on-ios-passively/
 private val options = mapOf<Any?, Any>(CBCentralManagerOptionShowPowerAlertKey to false)
 
-internal object AppleBluetoothRequirements : BluetoothRequirements {
+internal class AppleBluetoothRequirements : BluetoothRequirements {
 
     // Need to hold strong-reference to CBCentralManager and its delegate while in use.
     private var managerRef: NSObject? = null

--- a/bluetooth/src/appleMain/kotlin/requirements/BluetoothRequirementsFactory.kt
+++ b/bluetooth/src/appleMain/kotlin/requirements/BluetoothRequirementsFactory.kt
@@ -5,4 +5,4 @@ import androidx.compose.runtime.remember
 
 @Composable
 public actual fun rememberBluetoothRequirementsFactory(): BluetoothRequirementsFactory =
-    remember { BluetoothRequirementsFactory { AppleBluetoothRequirements } }
+    remember { BluetoothRequirementsFactory { AppleBluetoothRequirements() } }


### PR DESCRIPTION
Resolves the following issues with the sample app:
- (iOS only) would get stuck thinking BLE was on—even when it was turned off
- `onDisconnected` action could trigger (and result in attempted reconnects) on BLE disabled (because BLE disabled and disconnect states can come in at nearly the same time)