### PR TITLE
Adopt new Khronicle logging API

### DIFF
--- a/app/src/commonMain/kotlin/HeadlessApp.kt
+++ b/app/src/commonMain/kotlin/HeadlessApp.kt
@@ -12,6 +12,8 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.io.IOException
 
+private const val TAG = "App/Headless"
+
 suspend fun CoroutineScope.headlessApp() {
     Log.info(tag = TAG) { "Searching for SensorTag..." }
     val advertisement = SensorTag.scanner.advertisements.first()

--- a/app/src/commonMain/kotlin/HeadlessApp.kt
+++ b/app/src/commonMain/kotlin/HeadlessApp.kt
@@ -13,9 +13,9 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.io.IOException
 
 suspend fun CoroutineScope.headlessApp() {
-    Log.info { "Searching for SensorTag..." }
+    Log.info(LogTag) { "Searching for SensorTag..." }
     val advertisement = SensorTag.scanner.advertisements.first()
-    Log.info { "Found $advertisement" }
+    Log.info(LogTag) { "Found $advertisement" }
 
     val sensorTag = Peripheral(advertisement) {
         logging {
@@ -24,26 +24,26 @@ suspend fun CoroutineScope.headlessApp() {
     }.let(::SensorTag)
 
     sensorTag.gyro.onEach { rotation ->
-        Log.info { rotation.toString() }
+        Log.info(LogTag) { rotation.toString() }
     }.launchIn(this)
 
-    Log.info { "Configuring auto connector" }
+    Log.info(LogTag) { "Configuring auto connector" }
     sensorTag.state.onEach { state ->
-        Log.info { "Received state: $state" }
+        Log.info(LogTag) { "Received state: $state" }
         if (state is Disconnected) {
             try {
-                Log.verbose { "Attempting connection" }
+                Log.verbose(LogTag) { "Attempting connection" }
                 sensorTag.connect()
             } catch (e: IOException) {
-                Log.error(e) { "Connect failed." }
+                Log.error(LogTag, e) { "Connect failed." }
                 throw e
             }
-            Log.verbose { "Waiting to reconnect" }
+            Log.verbose(LogTag) { "Waiting to reconnect" }
             delay(2.seconds) // Throttle reconnects so we don't hammer the system if connection immediately drops.
         }
     }.launchIn(this).apply {
         invokeOnCompletion { cause ->
-            Log.warn(cause) { "Auto connector complete" }
+            Log.warn(LogTag, cause) { "Auto connector complete" }
         }
     }
 }

--- a/app/src/commonMain/kotlin/HeadlessApp.kt
+++ b/app/src/commonMain/kotlin/HeadlessApp.kt
@@ -13,9 +13,9 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.io.IOException
 
 suspend fun CoroutineScope.headlessApp() {
-    Log.info(LogTag) { "Searching for SensorTag..." }
+    Log.info(tag = TAG) { "Searching for SensorTag..." }
     val advertisement = SensorTag.scanner.advertisements.first()
-    Log.info(LogTag) { "Found $advertisement" }
+    Log.info(tag = TAG) { "Found $advertisement" }
 
     val sensorTag = Peripheral(advertisement) {
         logging {
@@ -24,26 +24,26 @@ suspend fun CoroutineScope.headlessApp() {
     }.let(::SensorTag)
 
     sensorTag.gyro.onEach { rotation ->
-        Log.info(LogTag) { rotation.toString() }
+        Log.info(tag = TAG) { rotation.toString() }
     }.launchIn(this)
 
-    Log.info(LogTag) { "Configuring auto connector" }
+    Log.info(tag = TAG) { "Configuring auto connector" }
     sensorTag.state.onEach { state ->
-        Log.info(LogTag) { "Received state: $state" }
+        Log.info(tag = TAG) { "Received state: $state" }
         if (state is Disconnected) {
             try {
-                Log.verbose(LogTag) { "Attempting connection" }
+                Log.verbose(tag = TAG) { "Attempting connection" }
                 sensorTag.connect()
             } catch (e: IOException) {
-                Log.error(LogTag, e) { "Connect failed." }
+                Log.error(tag = TAG, throwable = e) { "Connect failed." }
                 throw e
             }
-            Log.verbose(LogTag) { "Waiting to reconnect" }
+            Log.verbose(tag = TAG) { "Waiting to reconnect" }
             delay(2.seconds) // Throttle reconnects so we don't hammer the system if connection immediately drops.
         }
     }.launchIn(this).apply {
         invokeOnCompletion { cause ->
-            Log.warn(LogTag, cause) { "Auto connector complete" }
+            Log.warn(tag = TAG, throwable = cause) { "Auto connector complete" }
         }
     }
 }

--- a/app/src/commonMain/kotlin/Logging.kt
+++ b/app/src/commonMain/kotlin/Logging.kt
@@ -3,8 +3,6 @@ package com.juul.sensortag
 import com.juul.khronicle.ConsoleLogger
 import com.juul.khronicle.Log
 
-internal const val TAG = "SensorTag"
-
 fun configureLogging() {
     Log.dispatcher.install(ConsoleLogger)
 }

--- a/app/src/commonMain/kotlin/Logging.kt
+++ b/app/src/commonMain/kotlin/Logging.kt
@@ -1,10 +1,10 @@
 package com.juul.sensortag
 
 import com.juul.khronicle.ConsoleLogger
-import com.juul.khronicle.ConstantTagGenerator
 import com.juul.khronicle.Log
 
+internal const val LogTag = "SensorTag"
+
 fun configureLogging() {
-    Log.tagGenerator = ConstantTagGenerator(tag = "SensorTag")
     Log.dispatcher.install(ConsoleLogger)
 }

--- a/app/src/commonMain/kotlin/Logging.kt
+++ b/app/src/commonMain/kotlin/Logging.kt
@@ -3,7 +3,7 @@ package com.juul.sensortag
 import com.juul.khronicle.ConsoleLogger
 import com.juul.khronicle.Log
 
-internal const val LogTag = "SensorTag"
+internal const val TAG = "SensorTag"
 
 fun configureLogging() {
     Log.dispatcher.install(ConsoleLogger)

--- a/app/src/commonMain/kotlin/SensorTag.kt
+++ b/app/src/commonMain/kotlin/SensorTag.kt
@@ -9,11 +9,6 @@ import com.juul.kable.characteristicOf
 import com.juul.kable.logs.Logging.Level.Events
 import com.juul.kable.service
 import com.juul.khronicle.Log
-import kotlin.coroutines.coroutineContext
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
-import kotlin.uuid.Uuid
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,6 +19,13 @@ import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.io.IOException
+import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.uuid.Uuid
+
+private const val TAG = "SensorTag"
 
 const val movementService16bitUuid = 0xAA80
 val movementServiceUuid = SensorTag.BaseUuid + movementService16bitUuid

--- a/app/src/commonMain/kotlin/SensorTag.kt
+++ b/app/src/commonMain/kotlin/SensorTag.kt
@@ -109,15 +109,15 @@ class SensorTag(private val peripheral: Peripheral) {
         .map { it * GyroMultiplier }
 
     suspend fun connect() {
-        Log.info { "Connecting" }
+        Log.info(LogTag) { "Connecting" }
         try {
             peripheral.connect().launch { monitorRssi() }
             _battery.value = readBatteryLevel()
             _periodMillis.value = readGyroPeriod()
             enableGyro()
-            Log.info { "Connected" }
+            Log.info(LogTag) { "Connected" }
         } catch (e: IOException) {
-            Log.warn(e) { "Connection attempt failed" }
+            Log.warn(LogTag, e) { "Connection attempt failed" }
             peripheral.disconnect()
         }
     }
@@ -131,13 +131,13 @@ class SensorTag(private val peripheral: Peripheral) {
             while (coroutineContext.isActive) {
                 _rssi.value = peripheral.rssi()
 
-                Log.debug { "RSSI: ${_rssi.value}" }
+                Log.debug(LogTag) { "RSSI: ${_rssi.value}" }
                 delay(rssiInterval)
             }
         } catch (e: UnsupportedOperationException) {
             // As of Chrome 128, RSSI is not yet supported (even with
             // `chrome://flags/#enable-experimental-web-platform-features` flag enabled).
-            Log.warn(e) { "RSSI is not supported" }
+            Log.warn(LogTag, e) { "RSSI is not supported" }
         }
     }
 
@@ -148,9 +148,9 @@ class SensorTag(private val peripheral: Peripheral) {
         val value = period.inWholeMilliseconds / 10
         val data = byteArrayOf(value.toByte())
 
-        Log.verbose { "Writing gyro period of $period" }
+        Log.verbose(LogTag) { "Writing gyro period of $period" }
         peripheral.write(movementPeriodCharacteristic, data, WithResponse)
-        Log.info { "Writing gyro period complete" }
+        Log.info(LogTag) { "Writing gyro period complete" }
     }
 
     /** Period within the range 100-2550 ms. */
@@ -160,9 +160,9 @@ class SensorTag(private val peripheral: Peripheral) {
     }
 
     private suspend fun enableGyro() {
-        Log.info { "Enabling gyro" }
+        Log.info(LogTag) { "Enabling gyro" }
         peripheral.write(movementConfigCharacteristic, byteArrayOf(0x7F, 0x0), WithResponse)
-        Log.info { "Gyro enabled" }
+        Log.info(LogTag) { "Gyro enabled" }
     }
 
     private suspend fun disableGyro() {

--- a/app/src/commonMain/kotlin/SensorTag.kt
+++ b/app/src/commonMain/kotlin/SensorTag.kt
@@ -109,15 +109,15 @@ class SensorTag(private val peripheral: Peripheral) {
         .map { it * GyroMultiplier }
 
     suspend fun connect() {
-        Log.info(LogTag) { "Connecting" }
+        Log.info(tag = TAG) { "Connecting" }
         try {
             peripheral.connect().launch { monitorRssi() }
             _battery.value = readBatteryLevel()
             _periodMillis.value = readGyroPeriod()
             enableGyro()
-            Log.info(LogTag) { "Connected" }
+            Log.info(tag = TAG) { "Connected" }
         } catch (e: IOException) {
-            Log.warn(LogTag, e) { "Connection attempt failed" }
+            Log.warn(tag = TAG, throwable = e) { "Connection attempt failed" }
             peripheral.disconnect()
         }
     }
@@ -131,13 +131,13 @@ class SensorTag(private val peripheral: Peripheral) {
             while (coroutineContext.isActive) {
                 _rssi.value = peripheral.rssi()
 
-                Log.debug(LogTag) { "RSSI: ${_rssi.value}" }
+                Log.debug(tag = TAG) { "RSSI: ${_rssi.value}" }
                 delay(rssiInterval)
             }
         } catch (e: UnsupportedOperationException) {
             // As of Chrome 128, RSSI is not yet supported (even with
             // `chrome://flags/#enable-experimental-web-platform-features` flag enabled).
-            Log.warn(LogTag, e) { "RSSI is not supported" }
+            Log.warn(tag = TAG, throwable = e) { "RSSI is not supported" }
         }
     }
 
@@ -148,9 +148,9 @@ class SensorTag(private val peripheral: Peripheral) {
         val value = period.inWholeMilliseconds / 10
         val data = byteArrayOf(value.toByte())
 
-        Log.verbose(LogTag) { "Writing gyro period of $period" }
+        Log.verbose(tag = TAG) { "Writing gyro period of $period" }
         peripheral.write(movementPeriodCharacteristic, data, WithResponse)
-        Log.info(LogTag) { "Writing gyro period complete" }
+        Log.info(tag = TAG) { "Writing gyro period complete" }
     }
 
     /** Period within the range 100-2550 ms. */
@@ -160,9 +160,9 @@ class SensorTag(private val peripheral: Peripheral) {
     }
 
     private suspend fun enableGyro() {
-        Log.info(LogTag) { "Enabling gyro" }
+        Log.info(tag = TAG) { "Enabling gyro" }
         peripheral.write(movementConfigCharacteristic, byteArrayOf(0x7F, 0x0), WithResponse)
-        Log.info(LogTag) { "Gyro enabled" }
+        Log.info(tag = TAG) { "Gyro enabled" }
     }
 
     private suspend fun disableGyro() {

--- a/app/src/commonMain/kotlin/features/sensor/SensorScreenModel.kt
+++ b/app/src/commonMain/kotlin/features/sensor/SensorScreenModel.kt
@@ -4,8 +4,8 @@ import cafe.adriel.voyager.core.model.ScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.juul.kable.State
 import com.juul.khronicle.Log
-import com.juul.sensortag.LogTag
 import com.juul.sensortag.SensorTag
+import com.juul.sensortag.TAG
 import com.juul.sensortag.bluetooth.requirements.BluetoothRequirements
 import com.juul.sensortag.bluetooth.requirements.Deficiency.BluetoothOff
 import com.juul.sensortag.coroutines.flow.withStartTime
@@ -71,7 +71,7 @@ class SensorScreenModel(
 
     init {
         onDisconnected {
-            Log.info(LogTag) { "Reconnecting..." }
+            Log.info(tag = TAG) { "Reconnecting..." }
             sensorTag.connect()
         }
     }

--- a/app/src/commonMain/kotlin/features/sensor/SensorScreenModel.kt
+++ b/app/src/commonMain/kotlin/features/sensor/SensorScreenModel.kt
@@ -5,7 +5,6 @@ import cafe.adriel.voyager.core.model.screenModelScope
 import com.juul.kable.State
 import com.juul.khronicle.Log
 import com.juul.sensortag.SensorTag
-import com.juul.sensortag.TAG
 import com.juul.sensortag.bluetooth.requirements.BluetoothRequirements
 import com.juul.sensortag.bluetooth.requirements.Deficiency.BluetoothOff
 import com.juul.sensortag.coroutines.flow.withStartTime
@@ -30,6 +29,8 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+
+private const val TAG = "SensorScreenModel"
 
 class SensorScreenModel(
     bluetoothRequirements: BluetoothRequirements,

--- a/app/src/commonMain/kotlin/features/sensor/SensorScreenModel.kt
+++ b/app/src/commonMain/kotlin/features/sensor/SensorScreenModel.kt
@@ -4,6 +4,7 @@ import cafe.adriel.voyager.core.model.ScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.juul.kable.State
 import com.juul.khronicle.Log
+import com.juul.sensortag.LogTag
 import com.juul.sensortag.SensorTag
 import com.juul.sensortag.bluetooth.requirements.BluetoothRequirements
 import com.juul.sensortag.bluetooth.requirements.Deficiency.BluetoothOff
@@ -70,7 +71,7 @@ class SensorScreenModel(
 
     init {
         onDisconnected {
-            Log.info { "Reconnecting..." }
+            Log.info(LogTag) { "Reconnecting..." }
             sensorTag.connect()
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.7.1
 desugar = { module = "com.android.tools:desugar_jdk_libs", version = "2.1.5" }
 kable = { module = "com.juul.kable:kable-core", version.ref = "kable" }
 kable-permissions = { module = "com.juul.kable:kable-default-permissions", version.ref = "kable" }
-khronicle = { module = "com.juul.khronicle:khronicle-core", version = "1.0.0" }
+khronicle = { module = "com.juul.khronicle:khronicle-core", version = "1.1.0" }
 krayon-axis = { module = "com.juul.krayon:axis", version.ref = "krayon" }
 krayon-compose = { module = "com.juul.krayon:compose", version.ref = "krayon" }
 krayon-scale = { module = "com.juul.krayon:scale", version.ref = "krayon" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ compose-activity = { module = "androidx.activity:activity-compose", version = "1
 compose-ui = { module = "androidx.compose.ui:ui", version = "1.9.5" }
 coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.8.0-0.6.x-compat" }
+datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.8.0" }
 desugar = { module = "com.android.tools:desugar_jdk_libs", version = "2.1.5" }
 kable = { module = "com.juul.kable:kable-core", version.ref = "kable" }
 kable-permissions = { module = "com.juul.kable:kable-default-permissions", version.ref = "kable" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.7.1
 desugar = { module = "com.android.tools:desugar_jdk_libs", version = "2.1.5" }
 kable = { module = "com.juul.kable:kable-core", version.ref = "kable" }
 kable-permissions = { module = "com.juul.kable:kable-default-permissions", version.ref = "kable" }
-khronicle = { module = "com.juul.khronicle:khronicle-core", version = "1.1.0" }
+khronicle = { module = "com.juul.khronicle:khronicle-core", version = "1.0.0" }
 krayon-axis = { module = "com.juul.krayon:axis", version.ref = "krayon" }
 krayon-compose = { module = "com.juul.krayon:compose", version.ref = "krayon" }
 krayon-scale = { module = "com.juul.krayon:scale", version.ref = "krayon" }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Renovate PR #539 (`renovate/com.juul.khronicle-khronicle-core-1.x`) bumps `com.juul.khronicle:khronicle-core` from `0.5.2` to `1.1.0`, but every CI job (Android, iOS, Webapp) fails. Three independent breaking changes are mixed into the v1 line:

1. **Source-incompatible API removals (all of v1.x).** Khronicle 1.0.0 [removed the deprecated `Log.*` overloads](https://github.com/JuulLabs/khronicle/pull/194) as well as `Log.tagGenerator` and `ConstantTagGenerator`. Every `Log.verbose/debug/info/warn/error/assert/dynamic` call now requires an explicit `tag: String` as the first argument. This caused the `compileCommonMainKotlinMetadata` and JS errors:

   ```
   e: …/Logging.kt:4:27 Unresolved reference 'ConstantTagGenerator'.
   e: …/Logging.kt:8:9  Unresolved reference 'tagGenerator'.
   e: …/HeadlessApp.kt:16:9 No value passed for parameter 'tag'.
   e: …/HeadlessApp.kt:38:27 Argument type mismatch: actual type is 'IOException', but 'String' was expected.
   …
   ```

2. **Khronicle 1.1.0 raises its Android `compileSdk` floor to 36.** Our app currently compiles against `android-35`, which broke `:app:checkDebugAarMetadata`:

   ```
   1.  Dependency 'com.juul.khronicle:khronicle-core-android:1.1.0' requires libraries
       and applications that depend on it to compile against version 36 or later of the
       Android APIs.
       :app is currently compiled against android-35.
   ```

3. **Khronicle 1.1.0 ships klibs built against Kotlin 2.3.21.** Our project is on Kotlin 2.2.21, so the iOS klib cannot be resolved (KLIB ABI mismatch) and the JS source set fails with cascading "Unresolved reference 'Boolean'/'Unit'/'ByteArray'" errors:

   ```
   e: KLIB resolver: Could not find ".../khronicle-core-iosArm64Main.klib" in […]
   ```

   (Khronicle 1.1.0's Gradle module declares `kotlin-stdlib { requires "2.3.21" }`.)

## What

This PR isolates concern #1 (the actual khronicle migration) from #2 and #3:

- **`gradle/libs.versions.toml`**: pin khronicle to `1.0.0`. 1.0.0 ships the same v1 API surface, but its Android AAR has `minCompileSdk=1` and its klibs are built against Kotlin 2.2.21, so it works with the project's existing toolchain unchanged.
- **`Logging.kt`**: drop the `ConstantTagGenerator` / `Log.tagGenerator` setup and expose a top-level `internal const val LogTag = "SensorTag"` for call sites to pass.
- **`HeadlessApp.kt`, `SensorTag.kt`, `SensorScreenModel.kt`**: pass `LogTag` (and the throwable, where applicable) explicitly to every `Log.*` call.

The Android compileSdk bump and the Kotlin 2.3 upgrade should be handled in a separate PR when the team is ready to take on those wider changes; the next Renovate PR for `1.0.0` → `1.1.x` will surface them again.

## Verification

`./gradlew :app:compileKotlinJvm :app:compileCommonMainKotlinMetadata :app:compileKotlinJs` all build successfully locally. The Android task can't be run locally (no SDK on this VM) but the previous `checkDebugAarMetadata` failure was specifically about the 1.1.0 → compileSdk 36 requirement, which 1.0.0 does not impose.

Closes the CI failures on #539 (a follow-up Renovate PR may bump 1.0.0 → 1.1.x once Kotlin/AGP have been upgraded).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a4523f9-2c40-48d1-b9a8-0739657880ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a4523f9-2c40-48d1-b9a8-0739657880ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

