### PR TITLE
Bump Android compile version to `36`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.13.2"
-android-compile = "35"
+android-compile = "36"
 android-min = "21"
 android-target = "33"
 compose = "1.8.2"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Simple version bump for compile SDK with no code changes or security implications.
> 
> **Overview**
> Updates the Android compile SDK version from 35 to 36 in `gradle/libs.versions.toml`. This change allows the project to use Android 16 (API 36) APIs during compilation while maintaining the existing minimum SDK of 21 and target SDK of 33.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 077f746176d763224b917e4e1536312803acdf7a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->