### PR TITLE
Bump Android minimum API to `23`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.13.2"
 android-compile = "36"
-android-min = "21"
+android-min = "23"
 android-target = "33"
 compose = "1.8.2"
 jvm = "17"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Dropping API 21–22 support is a breaking change for users on those devices; runtime behavior is unchanged for supported versions.
> 
> **Overview**
> Raises the Android **minimum SDK** from API **21** to **23** in `gradle/libs.versions.toml` (`android-min`). The app module already reads this via `libs.versions.android.min`, so installs are no longer supported on devices below Android 6.0 (Marshmallow).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20ec3347b0a74558d7b24e425379e1bf0551b298. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->